### PR TITLE
7 add exr support to seqchk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - unreleased
+## [0.2.0] - unreleased
 
 ### Added
 
-- Add initial version of CLI utilities. `seqchk`, `seqcp`, `seqdo`, `seqls`, and `seqmv`.
+- Add exr support using [OpenEXR](https://pypi.org/project/OpenEXR/).
+- Add `seqgen` utility to make sequences from lists of framenumbers.
+
+## [0.1.1] - unreleased
+
+### Added
+
+- Add unit tests.
+
+## [0.1.0] - April 28, 2025
+
+### Added
+
+- Add initial version of CLI utilities. `seqchk`, `seqcp`, `seqdo`, `seqexp`, `seqls`, `seqmv`, and `seqrm`.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This will provide the command-line utilities:
 - `seqcp` - copy frames according to provided name patterns and frame range.
 - `seqdo` - do command(s), substituting in the provided frame range.
 - `seqexp` - expand a frame sequence, to evaluate it visually.
+- `seqgen` - given a list of framenumbers, make a frame sequence.
 - `seqls` - list frame sequences in the current directory.
 - `seqmv` - move (rename) frames according to provided name patterns and frame range.
 - `seqrm` - remove (delete) frames according to provided name patterns and frame range.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -6,10 +6,11 @@ Examples of using `noc` to interact with [Netflix Open Content](https://opencont
   - [Check Frames](#check-frames)
   - [Copy Frames](#copy-frames)
   - [Do a command](#do-a-command)
-    - [Expand a sequence](#expand-a-sequence)
-    - [List Sequences](#list-sequences)
-    - [Rename a Sequence](#rename-a-sequence)
-    - [Remove a Sequence](#remove-a-sequence)
+  - [Expand a sequence](#expand-a-sequence)
+  - [Generate a sequence](#generate-a-sequence)
+  - [List Sequences](#list-sequences)
+  - [Rename a Sequence](#rename-a-sequence)
+  - [Remove a Sequence](#remove-a-sequence)
 
 ## Check Frames
 
@@ -35,7 +36,7 @@ Do a command, substituting in a frame number for every frame in a sequence.
 seqdo
 ```
 
-### Expand a sequence
+## Expand a sequence
 
 Expand a sequence, to see the list of frames it represents.
 
@@ -43,7 +44,15 @@ Expand a sequence, to see the list of frames it represents.
 seqexp
 ```
 
-### List Sequences
+## Generate a sequence
+
+Generate a sequence, from a list of frames.
+
+```bash
+seqgen
+```
+
+## List Sequences
 
 List files, grouping them into sequences for readability.
 
@@ -51,7 +60,7 @@ List files, grouping them into sequences for readability.
 seqls
 ```
 
-### Rename a Sequence
+## Rename a Sequence
 
 Rename (move) files from one name to another, for every frame in a sequence.
 
@@ -59,7 +68,7 @@ Rename (move) files from one name to another, for every frame in a sequence.
 seqmv
 ```
 
-### Remove a Sequence
+## Remove a Sequence
 
 Remove (delete) files from disk, for every frame in a sequence.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,6 +35,7 @@ This will provide the command-line utilities:
 - `seqcp` - copy frames according to provided name patterns and frame range.
 - `seqdo` - do command(s), substituting in the provided frame range.
 - `seqexp` - expand a frame sequence, to evaluate it visually.
+- `seqgen` - make a frame sequence from a list of framenumbers.
 - `seqls` - list frame sequences in the current directory.
 - `seqmv` - move (rename) frames according to provided name patterns and frame range.
 - `seqrm` - remove (delete) frames according to provided name patterns and frame range.

--- a/docs/seqchk.md
+++ b/docs/seqchk.md
@@ -1,0 +1,3 @@
+# seqchk
+
+Check image files in sequences.

--- a/docs/seqcp.md
+++ b/docs/seqcp.md
@@ -1,0 +1,3 @@
+# seqcp
+
+Copy a sequence.

--- a/docs/seqdo.md
+++ b/docs/seqdo.md
@@ -1,0 +1,3 @@
+# seqdo
+
+Do action(s) on a sequence.

--- a/docs/seqexp.md
+++ b/docs/seqexp.md
@@ -1,0 +1,3 @@
+# seqexp
+
+Expand a sequence to frame numbers.

--- a/docs/seqgen.md
+++ b/docs/seqgen.md
@@ -1,0 +1,3 @@
+# seqgen
+
+Generate a sequence from a list of framenumbers.

--- a/docs/seqls.md
+++ b/docs/seqls.md
@@ -1,0 +1,3 @@
+# seqls
+
+List sequences.

--- a/docs/seqmv.md
+++ b/docs/seqmv.md
@@ -1,0 +1,3 @@
+# seqmv
+
+Move (rename) a sequence.

--- a/docs/seqrm.md
+++ b/docs/seqrm.md
@@ -1,0 +1,3 @@
+# seqrm
+
+Remove (delete) a sequence.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "vfx_seqtools"
-version = "0.1.1"
+version = "0.2.0"
 description = "CLI utilities for working with VFX frame sequences."
 authors = [
     {name = "Jason MacLeod", email = "jason.d.macleod@gmail.com"},
 ]
 dependencies = [
+    "OpenEXR>=3.3.0",
     "fileseq>=2.1.0",
     "pillow>=11.0.0",
     "typer>=0.7.0",
@@ -79,6 +80,7 @@ seqchk = "vfx_seqtools.seqchk_cli:app"
 seqcp = "vfx_seqtools.seqcp_cli:app"
 seqdo = "vfx_seqtools.seqdo_cli:app"
 seqexp = "vfx_seqtools.seqexp_cli:app"
+seqgen = "vfx_seqtools.seqgen_cli:app"
 seqls = "vfx_seqtools.seqls_cli:app"
 seqmv = "vfx_seqtools.seqmv_cli:app"
 seqrm = "vfx_seqtools.seqrm_cli:app"

--- a/src/vfx_seqtools/actions/seqchk.py
+++ b/src/vfx_seqtools/actions/seqchk.py
@@ -1,8 +1,10 @@
 import glob
 import logging
+import pathlib
 from typing import Annotated, Optional
 
 import fileseq
+import OpenEXR
 import typer
 from PIL import Image
 from rich.progress import (
@@ -29,11 +31,24 @@ def do_action(tupl: tuple) -> bool:
             logger.info(f"CHECK {framefile}")
 
         try:
-            Image.open(framefile).verify()
-            # print(f"{verify_response} was returned by verify")
-            Image.open(framefile)
-            # print(f"{im.filename.split('/')[-1]} is a valid image")
-            # im.show()
+            framepath = pathlib.Path(framefile)
+            if framepath.suffix.lower() == ".exr":
+                with OpenEXR.File(framefile):
+                    # header = infile.header()
+                    # print(f"type={header['type']}")
+                    # print(f"compression={header['compression']}")
+
+                    # RGB = infile.channels()["RGB"].pixels
+                    # height, width = RGB.shape[0:2]
+                    # print(f"width={width}, height={height}")
+                    # print(f"channels={infile.channels()}")
+                    pass
+            else:
+                Image.open(framefile).verify()
+                # print(f"{verify_response} was returned by verify")
+                Image.open(framefile)
+                # print(f"{im.filename.split('/')[-1]} is a valid image")
+                # im.show()
             return True
         except Exception:
             return False

--- a/src/vfx_seqtools/actions/seqgen.py
+++ b/src/vfx_seqtools/actions/seqgen.py
@@ -1,0 +1,48 @@
+import logging
+from typing import Annotated
+
+import fileseq
+import typer
+
+from vfx_seqtools import common_options
+from vfx_seqtools.decorators import attach_hook
+
+
+def to_list(frames: str) -> list:
+    """Return a list from a passed string of frame numbers.
+
+    Args:
+        frames (str): the frame numbers, comma or space-separated.
+
+    Returns:
+        list: list representation of the numbers.
+    """
+    if "," in frames:
+        return [int(i) for i in frames.split(",")]
+    elif " " in frames:
+        return [int(i) for i in frames.split()]
+    else:
+        return [int(i) for i in frames.split(",")]
+
+
+@attach_hook(common_options.logging_options, hook_output_kwarg="logger")
+@attach_hook(common_options.version_option, hook_output_kwarg="show_version")
+def seqgen(
+    frames: Annotated[
+        str,
+        typer.Argument(
+            help="A list of frames to consider, ex. '1,3,5,7'. Use quotes to surround space-separated values."
+        ),
+    ],
+    show_version: bool,
+    logger: logging.Logger,
+) -> None:
+    """
+    Generate a frame sequence from individual frame numbers.
+
+    'seqgen 1,3,5,7' - will return the frame sequence 1-7x2.
+    """
+    framelist = to_list(frames)
+    seq = fileseq.FrameSet(framelist)
+
+    print(seq.frange)

--- a/src/vfx_seqtools/actions/seqls.py
+++ b/src/vfx_seqtools/actions/seqls.py
@@ -12,6 +12,7 @@ from vfx_seqtools.decorators import attach_hook
 @attach_hook(common_options.logging_options, hook_output_kwarg="logger")
 @attach_hook(common_options.version_option, hook_output_kwarg="show_version")
 @attach_hook(common_options.sequence_only_option, hook_output_kwarg="only_on_sequences")
+@attach_hook(common_options.missing_frames_option, hook_output_kwarg="show_missing")
 def seqls(
     show_version: bool,
     logger: logging.Logger,
@@ -22,6 +23,7 @@ def seqls(
         ),
     ] = "",
     only_on_sequences: bool = False,
+    show_missing: bool = False,
 ) -> None:
     """
     List file sequences.
@@ -43,3 +45,7 @@ def seqls(
         if only_on_sequences and "@" not in str(seq) and "#" not in str(seq):
             continue
         print(f"{seq}")
+        if show_missing:
+            missing_frames = seq.invertedFrameRange()
+            if missing_frames:
+                print(f"Missing frames: {missing_frames}")

--- a/src/vfx_seqtools/common_options.py
+++ b/src/vfx_seqtools/common_options.py
@@ -126,6 +126,19 @@ def sequence_only_option(
     return only_sequences
 
 
+def missing_frames_option(
+    missing_frames: Annotated[
+        Optional[bool],
+        typer.Option(
+            "--missing-frames",
+            "-m",
+            help="Show missing frames in sequences.",
+        ),
+    ] = False,
+) -> Optional[bool]:
+    return missing_frames
+
+
 def frame_range_options(
     frame_start: Annotated[
         int,

--- a/src/vfx_seqtools/seqgen_cli.py
+++ b/src/vfx_seqtools/seqgen_cli.py
@@ -1,0 +1,16 @@
+"""CLI wrapper for seqgen."""
+
+import typer
+
+from vfx_seqtools.actions.seqgen import seqgen
+
+app = typer.Typer()
+
+# We use `ignore_unknown_options` to allow passing negative numbers in the frame range.
+# otherwise, the CLI would interpret the negative number in the range '-5-10' as an option.
+# https://github.com/fastapi/typer/discussions/798
+app.command(context_settings={"ignore_unknown_options": True})(seqgen)
+
+
+if __name__ == "__main__":
+    app()

--- a/tests/test_seqgen.py
+++ b/tests/test_seqgen.py
@@ -1,0 +1,44 @@
+"""Tests for the vfx-seqtools seqgen CLI utility."""
+
+import pytest
+from typer.testing import CliRunner
+
+from vfx_seqtools.seqgen_cli import app
+
+runner = CliRunner(mix_stderr=False)
+
+
+testdata = [
+    ("1-5\n", "1 2 3 4 5\n", "1,2,3,4,5\n"),
+    ("1-5,7-9\n", "1 2 3 4 5 7 8 9\n", "1,2,3,4,5,7,8,9\n"),
+    ("1-10x3\n", "1 4 7 10\n", "1,4,7,10\n"),
+    ("-3-5\n", "-3 -2 -1 0 1 2 3 4 5\n", "-3,-2,-1,0,1,2,3,4,5\n"),
+    ("-3-11x2\n", "-3 -1 1 3 5 7 9 11\n", "-3,-1,1,3,5,7,9,11\n"),
+]
+
+
+def test_app_reports_version() -> None:
+    """Test that the version is reported."""
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert "vfx-seqtools, version" in result.stdout
+
+
+@pytest.mark.parametrize("expected_string, input_spaces, input_commas", testdata)
+def test_seqgen_handles_spaces(
+    expected_string: str, input_spaces: str, input_commas: str
+) -> None:
+    """Test that the seqgen command generates a sequence from a space-separated set of framenumbers."""
+    result = runner.invoke(app, [input_spaces])
+    assert result.exit_code == 0
+    assert result.stdout == expected_string
+
+
+@pytest.mark.parametrize("expected_string, input_spaces, input_commas", testdata)
+def test_seqgen_handles_commas(
+    expected_string: str, input_spaces: str, input_commas: str
+) -> None:
+    """Test that the seqgen command generates a sequence from a comma-separated set of framenumbers."""
+    result = runner.invoke(app, [input_commas])
+    assert result.exit_code == 0
+    assert result.stdout == expected_string

--- a/tests/test_seqls.py
+++ b/tests/test_seqls.py
@@ -18,6 +18,13 @@ test_files = [
     "file.0005.exr",
 ]
 
+test_missing_files = [
+    "missingfile.0001.exr",
+    "missingfile.0002.exr",
+    "missingfile.0003.exr",
+    "missingfile.0005.exr",
+]
+
 
 def test_app_reports_version() -> None:
     """Test that the version is reported."""
@@ -42,3 +49,12 @@ def test_seqls_calls_fileseq_without_pattern(mocker: MockFixture) -> None:
     result = runner.invoke(app, [])
     assert result.exit_code == 0
     fileseq.findSequencesOnDisk.assert_called_once_with(".")
+
+
+def test_seqls_honors_missing_frame_option(mocker: MockFixture) -> None:
+    """Test that the seqls command honors the missing frame option."""
+    mocker.patch("glob.glob", return_value=test_missing_files)
+    result = runner.invoke(app, ["*.exr", "-m"])
+    assert result.exit_code == 0
+    glob.glob.assert_called_once_with("*.exr")  # type: ignore[attr-defined]
+    assert "Missing frames: 0004" in result.stdout


### PR DESCRIPTION
Add exr support - address #7 
Add missing frame option to `seqls` - address #5 
Add `seqgen` to generate a sequence representation from a list of frame numbers.