### PR TITLE
4 add more examples to documentation cookbook style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - unreleased
+## [0.2.1] - May 29, 2025
+
+### Changed
+
+- Pin `click` to version 8.1.8, as version 8.2 and greater drops support for Python 3.9. Revisit when Python 3.9 reaches end-of-life (est. Oct 2025).
+- Update documentation.
+
+## [0.2.0] - May 14, 2025
 
 ### Added
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -46,19 +46,13 @@ See [seqcp](./seqcp.md) for even more examples.
 
 ## Do a Command
 
-Run a shell command for each frame in a sequence, substituting `{}` with the frame number:
+Run a shell command for each frame in a sequence, substituting `@` with the frame number:
 
 ```bash
-seqdo 'echo Processing frame {}' 1001-1005
+seqdo 'echo Processing frame @' -f 1001-1005
 ```
 
-- Prints a message for each frame from 1001 to 1005.
-
-You can use `{src}` and `{dst}` if you specify input/output patterns:
-
-```bash
-seqdo 'convert {src} -resize 50% {dst}' input.%04d.jpg output.%04d.jpg 1001-1020
-```
+See [seqdo](./seqdo.md) for even more examples.
 
 ## Expand a Sequence
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,25 +1,32 @@
 # Examples
 
-This page provides practical examples of using the `vfx-seqtools` command-line utilities for working with frame sequences in Animation and VFX. Replace file patterns and frame ranges with those relevant to your project.
+This page provides examples using the `vfx-seqtools` command-line utilities with frame sequences. Replace file patterns and frame ranges with those relevant to your project.
 
-- [Check Frames](#check-frames)
-- [Copy Frames](#copy-frames)
-- [Do a Command](#do-a-command)
-- [Expand a Sequence](#expand-a-sequence)
-- [Generate a Sequence](#generate-a-sequence)
-- [List Sequences](#list-sequences)
-- [Rename a Sequence](#rename-a-sequence)
-- [Remove a Sequence](#remove-a-sequence)
+- [Examples](#examples)
+  - [Check Frames](#check-frames)
+  - [Copy Frames](#copy-frames)
+  - [Do a Command](#do-a-command)
+  - [Expand a Sequence](#expand-a-sequence)
+  - [Generate a Sequence](#generate-a-sequence)
+  - [List Sequences](#list-sequences)
+  - [Rename a Sequence](#rename-a-sequence)
+  - [Remove a Sequence](#remove-a-sequence)
 
 ## Check Frames
 
-Check a sequence for missing or corrupt files (e.g., missing frames in an image sequence):
+Check all files in the current directory:
 
 ```bash
-seqchk render.%04d.exr 1001-1050
+seqchk
 ```
 
-- Checks files like `render.1001.exr` to `render.1050.exr` for existence and validity.
+Check files in the current directory matching "COS*" as a sequence:
+
+```bash
+seqchk "COS*"
+```
+
+See [seqchk](./seqchk.md) for even more examples.
 
 ## Copy Frames
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -100,10 +100,12 @@ See [seqls](./seqls.md) for even more examples.
 Rename (move) a sequence of files to a new pattern:
 
 ```bash
-seqmv oldname.%04d.exr newname.%04d.exr 1001-1020
+seqmv oldname.####.exr newname.####.exr -f 1001-1020
 ```
 
 - Moves `oldname.1001.exr` to `newname.1001.exr`, etc.
+
+See [seqmv](./seqmv.md) for even more examples.
 
 ## Remove a Sequence
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -80,7 +80,7 @@ See [seqgen](./seqgen.md) for even more examples.
 
 ## List Sequences
 
-List all frame sequences in the current directory, grouping files by pattern:
+List all files in the current directory, grouping files by sequence:
 
 ```bash
 seqls
@@ -89,8 +89,8 @@ seqls
 - Output example:
 
 ```bash
-render.%04d.exr: 1001-1050
-comped.%04d.exr: 1001-1050
+render.1001-1050#.exr
+comped.1001-1050#.exr
 ```
 
 See [seqls](./seqls.md) for even more examples.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -112,7 +112,9 @@ See [seqmv](./seqmv.md) for even more examples.
 Delete a sequence of files from disk:
 
 ```bash
-seqrm temp.%04d.exr 1001-1020
+seqrm temp.####.exr -f 1001-1020
 ```
 
 - Removes `temp.1001.exr` to `temp.1020.exr`.
+
+See [seqrm](./seqrm.md) for even more examples.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -30,13 +30,19 @@ See [seqchk](./seqchk.md) for even more examples.
 
 ## Copy Frames
 
-Copy a sequence of frames to a new location or pattern:
+Copy frames 1001-1050 from `render.####.exr` to `comped.####.exr`:
 
 ```bash
-seqcp render.%04d.exr comped.%04d.exr 1001-1050
+seqcp render.####.exr comped.####.exr -f 1001-1050
 ```
 
-- Copies frames from `render.1001.exr` to `comped.1001.exr`, etc.
+Copy even frames in the range 1-10 from `animtexture.@.exr` to `animoffset.@.exr`, with a +10 frame offset:
+
+```bash
+seqcp animtexture.@.exr animoffset.@+10.exr -f 1-10x2
+```
+
+See [seqcp](./seqcp.md) for even more examples.
 
 ## Do a Command
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -56,7 +56,7 @@ See [seqdo](./seqdo.md) for even more examples.
 
 ## Expand a Sequence
 
-Show all frame numbers represented by a sequence expression:
+List all frame numbers represented by a sequence expression:
 
 ```bash
 seqexp 1001-1010x2
@@ -64,15 +64,19 @@ seqexp 1001-1010x2
 
 - Expands to: `1001 1003 1005 1007 1009`
 
+See [seqexp](./seqexp.md) for even more examples.
+
 ## Generate a Sequence
 
-Create empty files for a sequence of frames (useful for testing):
+Create a sequence expression from a list of frames:
 
 ```bash
-seqgen test.%04d.exr 1001-1005
+seqgen "1 2 3 4 5"
 ```
 
-- Creates files: `test.1001.exr` to `test.1005.exr`.
+- Output: `1-5`
+
+See [seqgen](./seqgen.md) for even more examples.
 
 ## List Sequences
 
@@ -83,10 +87,13 @@ seqls
 ```
 
 - Output example:
-  ```
-  render.%04d.exr: 1001-1050
-  comped.%04d.exr: 1001-1050
-  ```
+
+```bash
+render.%04d.exr: 1001-1050
+comped.%04d.exr: 1001-1050
+```
+
+See [seqls](./seqls.md) for even more examples.
 
 ## Rename a Sequence
 

--- a/docs/seqchk.md
+++ b/docs/seqchk.md
@@ -1,53 +1,54 @@
 # seqchk
 
-`seqchk` checks image files in a sequence for existence, completeness, and (optionally) validity. This is useful for verifying that all expected frames are present and not corrupt in a VFX or animation pipeline.
+`seqchk` checks image files for validity. This is useful for verifying that all files present are not corrupt or zero-length.
+
+It doesn't identify missing frames - use [`seqls -m`](./seqls.md) to identify missing frames.
 
 ## Usage
 
 ```bash
-seqchk PATTERN [FRAMES]
+seqchk [PATTERN] [OPTIONS]
 ```
 
-- `PATTERN`: Filename pattern using printf-style formatting (e.g., `render.%04d.exr`).
-- `FRAMES`: Frame range or sequence expression (e.g., `1001-1050`, `1-10x2`).
+- `PATTERN`: Optional filename pattern using shell wildcards (for example, `render.*.exr` or `filename.????.tif`).
 
 ## Options
 
 - `--verbose`, `-v`: Show detailed output for each file.
+- `--only-sequences`, `-o`: Only consider sequences, ignore other files.
 - `--strict`: Stop on the first error.
-- `--quiet`, `-q`: Only print errors.
 - `--dry-run`, `-n`: Show what would be checked, but do not actually check files.
 - `--version`: Show version and exit.
 
 ## Examples
 
-Check for missing or corrupt frames in a typical EXR sequence:
+Check all files in the current directory:
 
 ```bash
-seqchk render.%04d.exr 1001-1050
+seqchk
 ```
 
-Check a JPEG sequence with a custom frame range:
+Check only sequence files in the current directory:
 
 ```bash
-seqchk shotA.%03d.jpg 1-100
+seqchk -o
 ```
 
-Check only even frames:
+Check a JPEG sequence using a shell wildcard:
 
 ```bash
-seqchk comp.%04d.exr 1001-1050x2
+seqchk "shotA.*.jpg"
 ```
 
-Show detailed output for each file:
+Show line-by-line check output for each file:
 
 ```bash
-seqchk --verbose render.%04d.exr 1001-1010
+seqchk --verbose "render.*.exr"
 ```
 
 ## Output
 
-- Reports missing files, unreadable/corrupt files, and a summary of the check.
+- Reports unreadable/corrupt files per sequence checked.
 - Returns a nonzero exit code if any problems are found.
 
 ## Typical Use Cases

--- a/docs/seqcp.md
+++ b/docs/seqcp.md
@@ -8,9 +8,9 @@
 seqcp SRC_PATTERN DST_PATTERN [FRAMES]
 ```
 
-- `SRC_PATTERN`: Source filename pattern (e.g., `render.%04d.exr`).
-- `DST_PATTERN`: Destination filename pattern (e.g., `comped.%04d.exr`).
-- `FRAMES`: Frame range or sequence expression (e.g., `1001-1050`).
+- `SRC_PATTERN`: Source filename pattern (e.g., `render.#.exr`).
+- `DST_PATTERN`: Destination filename pattern (e.g., `comped.#.exr`).
+- `FRAMES`: Frame range or sequence expression (e.g., `-f 1001-1050`).
 
 ## Options
 
@@ -18,7 +18,6 @@ seqcp SRC_PATTERN DST_PATTERN [FRAMES]
 - `--interactive`, `-i`: Request confirmation before copying each file.
 - `--verbose`, `-v`: Show detailed output for each file.
 - `--strict`: Stop on the first error.
-- `--quiet`, `-q`: Only print errors.
 - `--version`: Show version and exit.
 
 ## Examples
@@ -26,19 +25,31 @@ seqcp SRC_PATTERN DST_PATTERN [FRAMES]
 Copy a sequence from one pattern to another:
 
 ```bash
-seqcp render.%04d.exr comped.%04d.exr 1001-1050
+seqcp render.####.exr comped.####.exr -f 1001-1050
 ```
 
-Copy only odd frames:
+Copy only odd frames in the range 1-100 (for example, 1, 3, 5, 7, ...):
 
 ```bash
-seqcp input.%04d.jpg output.%04d.jpg 1-100x2
+seqcp input.####.jpg output.####.jpg -f 1-100x2
 ```
 
 Preview what would be copied (dry run):
 
 ```bash
-seqcp --dry-run a.%04d.png b.%04d.png 10-20
+seqcp -n somefile.@.png anotherfile.@.png -f 10-20
+```
+
+Interactively copy files, prompting for each copy:
+
+```bash
+seqcp -i askfile.####.exr confirmfile.####.exr -f 10-20
+```
+
+Copy frames 10-20 and offset the destination frame numbering by +10 frames:
+
+```bash
+seqcp file.####.exr offsetfile.####+10.exr -f 10-20
 ```
 
 ## Output

--- a/docs/seqdo.md
+++ b/docs/seqdo.md
@@ -1,22 +1,19 @@
 # seqdo
 
-`seqdo` runs a shell command for each frame in a sequence, substituting frame numbers and file patterns. This is useful for batch processing or automating per-frame operations.
+`seqdo` runs a shell command for each frame in a sequence, substituting frame numbers. This is useful for batch processing or automating per-frame operations.
 
 ## Usage
 
 ```bash
-seqdo COMMAND [SRC_PATTERN] [DST_PATTERN] [FRAMES]
+seqdo COMMAND [FRAMES]
 ```
 
-- `COMMAND`: The shell command to run. Use `{}` for the frame number, `{src}` and `{dst}` for input/output filenames.
-- `SRC_PATTERN`: (Optional) Source filename pattern.
-- `DST_PATTERN`: (Optional) Destination filename pattern.
+- `COMMAND`: The shell command to run. Use `@` and `#` for frame number patterns.
 - `FRAMES`: Frame range or sequence expression.
 
 ## Options
 
 - `--dry-run`, `-n`: Show what would be done, but do not actually run commands.
-- `--thread-count N`: Run up to N commands in parallel.
 - `--verbose`, `-v`: Show detailed output for each command.
 - `--strict`: Stop on the first error.
 - `--quiet`, `-q`: Only print errors.
@@ -27,19 +24,13 @@ seqdo COMMAND [SRC_PATTERN] [DST_PATTERN] [FRAMES]
 Print a message for each frame:
 
 ```bash
-seqdo 'echo Processing frame {}' 1001-1005
+seqdo 'echo Processing frame @' -f 1001-1005
 ```
 
-Run an image conversion for each frame:
+Run an image conversion for each frame (requires that `convert` is available):
 
 ```bash
-seqdo 'convert {src} -resize 50% {dst}' input.%04d.jpg output.%04d.jpg 1001-1020
-```
-
-Run up to 4 commands in parallel:
-
-```bash
-seqdo --thread-count 4 'echo Frame {}' 1-10
+seqdo 'convert infile.@.jpg -resize 50% outfile.@.jpg' -f 1001-1020
 ```
 
 ## Output

--- a/docs/seqexp.md
+++ b/docs/seqexp.md
@@ -2,6 +2,8 @@
 
 `seqexp` expands a sequence expression into a list of frame numbers. Useful for visualizing or debugging frame ranges in VFX/animation workflows.
 
+Complements [seqgen](./seqgen.md)
+
 ## Usage
 
 ```bash
@@ -12,7 +14,8 @@ seqexp SEQUENCE
 
 ## Options
 
-- `--pad`, `-p`: List frame numbers with zero padding, number of zeros to pad. [default: 0]                                    │
+- `--comma-separate`, `-c`: List frame numbers with comma separation. [default: space-separation]
+- `--pad`, `-p`: List frame numbers with zero padding, number of zeros to pad. [default: 0]
 - `--long-list`, `-l`: Long listing of frame numbers, one per line.
 - `--version`: Show version and exit.
 
@@ -25,6 +28,14 @@ seqexp 1001-1005
 ```
 
 - Output: `1001 1002 1003 1004 1005`
+
+Expand a simple range with comma separation:
+
+```bash
+seqexp -c 1001-1005
+```
+
+- Output: `1001,1002,1003,1004,1005`
 
 Expand a range with step:
 

--- a/docs/seqexp.md
+++ b/docs/seqexp.md
@@ -12,6 +12,8 @@ seqexp SEQUENCE
 
 ## Options
 
+- `--pad`, `-p`: List frame numbers with zero padding, number of zeros to pad. [default: 0]                                    │
+- `--long-list`, `-l`: Long listing of frame numbers, one per line.
 - `--version`: Show version and exit.
 
 ## Examples
@@ -39,3 +41,22 @@ seqexp 1-5,10-12
 ```
 
 - Output: `1 2 3 4 5 10 11 12`
+
+Expand a complex sequence, with 4-digit padding and long listing:
+
+```bash
+seqexp -l -p 4 1-5,10-12
+```
+
+- Output:
+
+```bash
+0001
+0002
+0003
+0004
+0005
+0010
+0011
+0012
+```

--- a/docs/seqgen.md
+++ b/docs/seqgen.md
@@ -1,40 +1,39 @@
 # seqgen
 
-`seqgen` generates empty files for a sequence of frames, useful for testing or creating placeholder files in VFX/animation workflows.
+`seqgen` generates a sequence expression from a list of framenumbers. Useful for visualizing or debugging frame ranges in VFX/animation workflows.
+
+Complements [seqexp](./seqexp.md)
 
 ## Usage
 
 ```bash
-seqgen PATTERN [FRAMES]
+seqgen [FRAMES]
 ```
 
-- `PATTERN`: Filename pattern (e.g., `test.%04d.exr`).
-- `FRAMES`: Frame range or sequence expression (e.g., `1001-1005`).
+- `FRAMES`: Frames to consider for a sequence expression (for example, `1,2,3,4,5`).
 
 ## Options
 
-- `--dry-run`, `-n`: Show what would be created, but do not actually create files.
-- `--verbose`, `-v`: Show detailed output for each file.
-- `--strict`: Stop on the first error.
-- `--quiet`, `-q`: Only print errors.
 - `--version`: Show version and exit.
 
 ## Examples
 
-Create empty EXR files for a range:
+Generate a sequence from a space-separated list of frames:
 
 ```bash
-seqgen test.%04d.exr 1001-1005
+seqgen "1 2 3 4 5"
 ```
 
-Create only even frames:
-
 ```bash
-seqgen test.%04d.exr 1002-1010x2
+1-5
 ```
 
-Preview what would be created (dry run):
+Generate a sequence from a comma-separated list of frames:
 
 ```bash
-seqgen --dry-run test.%04d.exr 1-3
+seqgen 5,10,15,20
+```
+
+```bash
+5-20x5
 ```

--- a/docs/seqls.md
+++ b/docs/seqls.md
@@ -16,14 +16,59 @@ seqls
 
 ## Examples
 
-List all sequences in the current directory:
+List all files in the current directory, with sequence grouping:
 
 ```bash
 seqls
 ```
 
 - Output example:
-  ```
-  render.%04d.exr: 1001-1050
-  comped.%04d.exr: 1001-1050
-  ```
+
+```bash
+./COS_002_0045_comp_NFX_v001.1001-1054#.exr
+./meridian.21000-21006,21008@@@@@.tif
+./testcp.11-19x2#.tif
+./notsequence.tif
+```
+
+List only sequences in the current directory:
+
+```bash
+seqls -o
+```
+
+- Output example:
+
+```bash
+./COS_002_0045_comp_NFX_v001.1001-1054#.exr
+./meridian.21000-21006,21008@@@@@.tif
+./testcp.11-19x2#.tif
+```
+
+List only sequences in the current directory, and identify missing frames:
+
+```bash
+seqls -o -m
+```
+
+- Output example:
+
+```bash
+./COS_002_0045_comp_NFX_v001.1001-1054#.exr
+./meridian.21000-21006,21008@@@@@.tif
+Missing frames: 21007
+./testcp.11-19x2#.tif
+Missing frames: 0012-0018x2
+```
+
+List only files matching "COS*":
+
+```bash
+seqls -o -m "COS*"
+```
+
+- Output example:
+
+```bash
+COS_002_0045_comp_NFX_v001.1001-1054#.exr
+```

--- a/docs/seqls.md
+++ b/docs/seqls.md
@@ -10,6 +10,8 @@ seqls
 
 ## Options
 
+- `--missing-frames`, `-m`: List missing frames from sequences.
+- `--only-sequences`, `-o`: Only consider sequences, ignore other files.
 - `--version`: Show version and exit.
 
 ## Examples

--- a/docs/seqmv.md
+++ b/docs/seqmv.md
@@ -8,9 +8,9 @@
 seqmv SRC_PATTERN DST_PATTERN [FRAMES]
 ```
 
-- `SRC_PATTERN`: Source filename pattern (e.g., `oldname.%04d.exr`).
-- `DST_PATTERN`: Destination filename pattern (e.g., `newname.%04d.exr`).
-- `FRAMES`: Frame range or sequence expression (e.g., `1001-1020`).
+- `SRC_PATTERN`: Source filename pattern (e.g., `oldname.####.exr`).
+- `DST_PATTERN`: Destination filename pattern (e.g., `newname.####.exr`).
+- `FRAMES`: Frame range or sequence expression (e.g., `-f 1001-1020`).
 
 ## Options
 
@@ -18,7 +18,6 @@ seqmv SRC_PATTERN DST_PATTERN [FRAMES]
 - `--interactive`, `-i`: Request confirmation before moving each file.
 - `--verbose`, `-v`: Show detailed output for each file.
 - `--strict`: Stop on the first error.
-- `--quiet`, `-q`: Only print errors.
 - `--version`: Show version and exit.
 
 ## Examples
@@ -26,11 +25,23 @@ seqmv SRC_PATTERN DST_PATTERN [FRAMES]
 Rename a sequence to a new pattern:
 
 ```bash
-seqmv oldname.%04d.exr newname.%04d.exr 1001-1020
+seqmv oldname.####.exr newname.####.exr -f 1001-1020
 ```
 
 Preview what would be moved (dry run):
 
 ```bash
-seqmv --dry-run a.%04d.png b.%04d.png 10-20
+seqmv -n oldname.####.png newname.####.pnf -f 10-20
+```
+
+Interactively copy files, prompting for each copy:
+
+```bash
+seqmv -i askfile.####.exr confirmfile.####.exr -f 10-20
+```
+
+Move frames 10-20 and offset the destination frame numbering by +10 frames:
+
+```bash
+seqmv file.####.exr offsetfile.####+10.exr -f 10-20
 ```

--- a/docs/seqrm.md
+++ b/docs/seqrm.md
@@ -8,8 +8,8 @@
 seqrm PATTERN [FRAMES]
 ```
 
-- `PATTERN`: Filename pattern (e.g., `temp.%04d.exr`).
-- `FRAMES`: Frame range or sequence expression (e.g., `1001-1020`).
+- `PATTERN`: Filename pattern (e.g., `temp.####.exr`).
+- `FRAMES`: Frame range or sequence expression (e.g., `-f 1001-1020`).
 
 ## Options
 
@@ -17,7 +17,6 @@ seqrm PATTERN [FRAMES]
 - `--interactive`, `-i`: Request confirmation before deleting each file.
 - `--verbose`, `-v`: Show detailed output for each file.
 - `--strict`: Stop on the first error.
-- `--quiet`, `-q`: Only print errors.
 - `--version`: Show version and exit.
 
 ## Examples
@@ -25,11 +24,17 @@ seqrm PATTERN [FRAMES]
 Remove a sequence of files:
 
 ```bash
-seqrm temp.%04d.exr 1001-1020
+seqrm temp.####.exr -f 1001-1020
 ```
 
 Preview what would be deleted (dry run):
 
 ```bash
-seqrm --dry-run temp.%04d.exr 1-3
+seqrm -n temp.####.exr -f 1-3
+```
+
+Interactively remove files, prompting for each copy:
+
+```bash
+seqrm -i askfile.####.exr confirmfile.####.exr -f 10-20
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,13 @@
 [project]
 name = "vfx_seqtools"
-version = "0.2.0"
+version = "0.2.1"
 description = "CLI utilities for working with VFX frame sequences."
 authors = [
     {name = "Jason MacLeod", email = "jason.d.macleod@gmail.com"},
 ]
 dependencies = [
     "OpenEXR>=3.3.0",
+    "click<=8.1.8",
     "fileseq>=2.1.0",
     "pillow>=11.0.0",
     "typer>=0.7.0",

--- a/src/vfx_seqtools/actions/seqchk.py
+++ b/src/vfx_seqtools/actions/seqchk.py
@@ -56,9 +56,6 @@ def do_action(tupl: tuple) -> bool:
 
 @attach_hook(common_options.logging_options, hook_output_kwarg="logger")
 @attach_hook(common_options.dry_run_option, hook_output_kwarg="is_dryrun")
-@attach_hook(common_options.frame_range_options, hook_output_kwarg="frame_range")
-@attach_hook(common_options.frame_seq_options, hook_output_kwarg="frame_seq")
-@attach_hook(common_options.threading_option, hook_output_kwarg="thread_count")
 @attach_hook(common_options.verbose_option, hook_output_kwarg="be_verbose")
 @attach_hook(common_options.strict_option, hook_output_kwarg="be_strict")
 @attach_hook(common_options.version_option, hook_output_kwarg="show_version")
@@ -74,10 +71,7 @@ def seqchk(
     ] = "",
     be_verbose: Optional[bool] = False,
     be_strict: Optional[bool] = False,
-    frame_range: Optional[tuple[int, int, int]] = (0, 0, 0),
-    frame_seq: Optional[str] = "",
     is_dryrun: Optional[bool] = False,
-    thread_count: Optional[int] = 0,
     only_on_sequences: bool = False,
 ) -> None:
     """

--- a/src/vfx_seqtools/actions/seqcp.py
+++ b/src/vfx_seqtools/actions/seqcp.py
@@ -45,7 +45,6 @@ def do_action(tupl: tuple) -> None:
 @attach_hook(common_options.frame_range_options, hook_output_kwarg="frame_range")
 @attach_hook(common_options.frame_seq_options, hook_output_kwarg="frame_seq")
 @attach_hook(common_options.logging_options, hook_output_kwarg="logger")
-@attach_hook(common_options.threading_option, hook_output_kwarg="thread_count")
 @attach_hook(common_options.interactive_option, hook_output_kwarg="be_interactive")
 @attach_hook(common_options.verbose_option, hook_output_kwarg="be_verbose")
 @attach_hook(common_options.strict_option, hook_output_kwarg="be_strict")
@@ -63,7 +62,6 @@ def seqcp(
     frame_seq: str = "",
     is_dryrun: Optional[bool] = False,
     show_version: Optional[bool] = False,
-    thread_count: Optional[int] = 0,
 ) -> None:
     """
     Copy files from <SRC> to <DST>, using the provided framerange. # (padded) and @ (unpadded) are replaced with the frame number.

--- a/src/vfx_seqtools/actions/seqexp.py
+++ b/src/vfx_seqtools/actions/seqexp.py
@@ -40,6 +40,14 @@ def seqexp(
             help="List frame numbers with zero padding, number of zeros to pad.",
         ),
     ] = 0,
+    comma_separate: Annotated[
+        bool,
+        typer.Option(
+            "--comma-separate",
+            "-c",
+            help="Separate frame numbers with commas (default is spaces).",
+        ),
+    ] = False,
     long_list: Annotated[
         bool,
         typer.Option(
@@ -60,4 +68,7 @@ def seqexp(
         for frame in seq:
             print(pad_frame(frame, pad))
     else:
-        print(" ".join(str(pad_frame(frame, pad)) for frame in seq))
+        if comma_separate:
+            print(",".join(str(pad_frame(frame, pad)) for frame in seq))
+        else:
+            print(" ".join(str(pad_frame(frame, pad)) for frame in seq))

--- a/src/vfx_seqtools/actions/seqmv.py
+++ b/src/vfx_seqtools/actions/seqmv.py
@@ -45,7 +45,6 @@ def do_action(tupl: tuple) -> None:
 @attach_hook(common_options.frame_range_options, hook_output_kwarg="frame_range")
 @attach_hook(common_options.frame_seq_options, hook_output_kwarg="frame_seq")
 @attach_hook(common_options.logging_options, hook_output_kwarg="logger")
-@attach_hook(common_options.threading_option, hook_output_kwarg="thread_count")
 @attach_hook(common_options.interactive_option, hook_output_kwarg="be_interactive")
 @attach_hook(common_options.verbose_option, hook_output_kwarg="be_verbose")
 @attach_hook(common_options.strict_option, hook_output_kwarg="be_strict")
@@ -63,7 +62,6 @@ def seqmv(
     frame_seq: str = "",
     is_dryrun: Optional[bool] = False,
     show_version: Optional[bool] = False,
-    thread_count: Optional[int] = 0,
 ) -> None:
     """
     Move(rename) files from <SRC> to <DST>, using the provided framerange.

--- a/tests/test_seqexp.py
+++ b/tests/test_seqexp.py
@@ -9,29 +9,59 @@ runner = CliRunner(mix_stderr=False)
 
 
 testdata = [
-    ("1-5", "1 2 3 4 5\n", "1\n2\n3\n4\n5\n"),
-    ("1-5,7-9", "1 2 3 4 5 7 8 9\n", "1\n2\n3\n4\n5\n7\n8\n9\n"),
-    ("1-10x3", "1 4 7 10\n", "1\n4\n7\n10\n"),
-    ("10-20y5", "11 12 13 14 16 17 18 19\n", "11\n12\n13\n14\n16\n17\n18\n19\n"),
-    ("3-10:3", "3 6 9 5 7 4 8 10\n", "3\n6\n9\n5\n7\n4\n8\n10\n"),
-    ("-3-5", "-3 -2 -1 0 1 2 3 4 5\n", "-3\n-2\n-1\n0\n1\n2\n3\n4\n5\n"),
+    ("1-5", "1 2 3 4 5\n", "1,2,3,4,5\n", "1\n2\n3\n4\n5\n"),
+    ("1-5,7-9", "1 2 3 4 5 7 8 9\n", "1,2,3,4,5,7,8,9\n", "1\n2\n3\n4\n5\n7\n8\n9\n"),
+    ("1-10x3", "1 4 7 10\n", "1,4,7,10\n", "1\n4\n7\n10\n"),
+    (
+        "10-20y5",
+        "11 12 13 14 16 17 18 19\n",
+        "11,12,13,14,16,17,18,19\n",
+        "11\n12\n13\n14\n16\n17\n18\n19\n",
+    ),
+    ("3-10:3", "3 6 9 5 7 4 8 10\n", "3,6,9,5,7,4,8,10\n", "3\n6\n9\n5\n7\n4\n8\n10\n"),
+    (
+        "-3-5",
+        "-3 -2 -1 0 1 2 3 4 5\n",
+        "-3,-2,-1,0,1,2,3,4,5\n",
+        "-3\n-2\n-1\n0\n1\n2\n3\n4\n5\n",
+    ),
 ]
 
 testdata_padded = [
-    ("1-5", 4, "0001 0002 0003 0004 0005\n", "0001\n0002\n0003\n0004\n0005\n"),
+    (
+        "1-5",
+        4,
+        "0001 0002 0003 0004 0005\n",
+        "0001,0002,0003,0004,0005\n",
+        "0001\n0002\n0003\n0004\n0005\n",
+    ),
     (
         "1-5,7-9",
         3,
         "001 002 003 004 005 007 008 009\n",
+        "001,002,003,004,005,007,008,009\n",
         "001\n002\n003\n004\n005\n007\n008\n009\n",
     ),
-    ("1-10x3", 2, "01 04 07 10\n", "01\n04\n07\n10\n"),
-    ("10-20y5", 0, "11 12 13 14 16 17 18 19\n", "11\n12\n13\n14\n16\n17\n18\n19\n"),
-    ("3-10:3", 1, "3 6 9 5 7 4 8 10\n", "3\n6\n9\n5\n7\n4\n8\n10\n"),
+    ("1-10x3", 2, "01 04 07 10\n", "01,04,07,10\n", "01\n04\n07\n10\n"),
+    (
+        "10-20y5",
+        0,
+        "11 12 13 14 16 17 18 19\n",
+        "11,12,13,14,16,17,18,19\n",
+        "11\n12\n13\n14\n16\n17\n18\n19\n",
+    ),
+    (
+        "3-10:3",
+        1,
+        "3 6 9 5 7 4 8 10\n",
+        "3,6,9,5,7,4,8,10\n",
+        "3\n6\n9\n5\n7\n4\n8\n10\n",
+    ),
     (
         "-3-5",
         2,
         "-03 -02 -01 00 01 02 03 04 05\n",
+        "-03,-02,-01,00,01,02,03,04,05\n",
         "-03\n-02\n-01\n00\n01\n02\n03\n04\n05\n",
     ),
 ]
@@ -44,9 +74,14 @@ def test_app_reports_version() -> None:
     assert "vfx-seqtools, version" in result.stdout
 
 
-@pytest.mark.parametrize("input_string, expected_compact, expected_long", testdata)
+@pytest.mark.parametrize(
+    "input_string, expected_compact, expected_compact_comma, expected_long", testdata
+)
 def test_seqexp_expands_list_compact(
-    input_string: str, expected_compact: str, expected_long: str
+    input_string: str,
+    expected_compact: str,
+    expected_compact_comma: str,
+    expected_long: str,
 ) -> None:
     """Test that the seqexp command expands a list compactly."""
     result = runner.invoke(app, [input_string])
@@ -54,9 +89,29 @@ def test_seqexp_expands_list_compact(
     assert result.stdout == expected_compact
 
 
-@pytest.mark.parametrize("input_string, expected_compact, expected_long", testdata)
+@pytest.mark.parametrize(
+    "input_string, expected_compact, expected_compact_comma, expected_long", testdata
+)
+def test_seqexp_expands_list_compact_comma(
+    input_string: str,
+    expected_compact: str,
+    expected_compact_comma: str,
+    expected_long: str,
+) -> None:
+    """Test that the seqexp command expands a list compactly, with commas."""
+    result = runner.invoke(app, [input_string, "-c"])
+    assert result.exit_code == 0
+    assert result.stdout == expected_compact_comma
+
+
+@pytest.mark.parametrize(
+    "input_string, expected_compact, expected_compact_comma, expected_long", testdata
+)
 def test_seqexp_expands_list_long(
-    input_string: str, expected_compact: str, expected_long: str
+    input_string: str,
+    expected_compact: str,
+    expected_compact_comma: str,
+    expected_long: str,
 ) -> None:
     """Test that the seqexp command expands a list in long format."""
     result = runner.invoke(app, [input_string, "-l"])
@@ -65,10 +120,15 @@ def test_seqexp_expands_list_long(
 
 
 @pytest.mark.parametrize(
-    "input_string, padding, expected_compact, expected_long", testdata_padded
+    "input_string, padding, expected_compact, expected_compact_comma, expected_long",
+    testdata_padded,
 )
 def test_seqexp_expands_list_compact_padded(
-    input_string: str, padding: int, expected_compact: str, expected_long: str
+    input_string: str,
+    padding: int,
+    expected_compact: str,
+    expected_compact_comma: str,
+    expected_long: str,
 ) -> None:
     """Test that the seqexp command expands a list compactly, with padding."""
     result = runner.invoke(app, [input_string, "-p", str(padding)])
@@ -77,10 +137,32 @@ def test_seqexp_expands_list_compact_padded(
 
 
 @pytest.mark.parametrize(
-    "input_string, padding, expected_compact, expected_long", testdata_padded
+    "input_string, padding, expected_compact, expected_compact_comma, expected_long",
+    testdata_padded,
+)
+def test_seqexp_expands_list_compact_padded_comma(
+    input_string: str,
+    padding: int,
+    expected_compact: str,
+    expected_compact_comma: str,
+    expected_long: str,
+) -> None:
+    """Test that the seqexp command expands a list compactly, with padding and comma."""
+    result = runner.invoke(app, [input_string, "-c", "-p", str(padding)])
+    assert result.exit_code == 0
+    assert result.stdout == expected_compact_comma
+
+
+@pytest.mark.parametrize(
+    "input_string, padding, expected_compact, expected_compact_comma, expected_long",
+    testdata_padded,
 )
 def test_seqexp_expands_list_long_padded(
-    input_string: str, padding: int, expected_compact: str, expected_long: str
+    input_string: str,
+    padding: int,
+    expected_compact: str,
+    expected_compact_comma: str,
+    expected_long: str,
 ) -> None:
     """Test that the seqexp command expands a list in long format, with padding."""
     result = runner.invoke(app, [input_string, "-l", "-p", str(padding)])


### PR DESCRIPTION
Pin click to version 8.1.8 to retain python 3.9 support
remove unimplemented threading options - resolves #2 
add usage examples - resolves #4 
add comma separated listing to seqexp